### PR TITLE
Renaming of XP to user_experience

### DIFF
--- a/src/modules/level/addUserExperience.ts
+++ b/src/modules/level/addUserExperience.ts
@@ -7,12 +7,12 @@ import {calcLevel, xpToNextLevel} from "./levelHelper";
 /**
  * Add XP to a user and update their level if they have levelled up
  * @param user the user to add XP to
- * @param addedXP the amount of XP to add, must be greater than 0
+ * @param addedExperience the amount of XP to add, must be greater than 0
  */
-export async function addXP(user: GuildMember, addedXP: number) {
-	if (!user || addedXP <= 0) return;
+export async function addUserExperience(user: GuildMember, addedExperience: number) {
+	if (!user || addedExperience <= 0) return;
 
-	addedXP = Math.floor(addedXP);
+	addedExperience = Math.floor(addedExperience);
 
 	const levelRole: { [level: number]: Role | null } = {
 		0: snowflake.roles.levellingRole1,
@@ -27,11 +27,11 @@ export async function addXP(user: GuildMember, addedXP: number) {
 
 	const previousXP = levelData?.dezixp || 0;
 	const previousLevel = calcLevel(previousXP);
-	const newXP = previousXP + addedXP;
+	const newXP = previousXP + addedExperience;
 	const newLevel = calcLevel(newXP);
 	const levelUpXP = xpToNextLevel(previousXP);
 
-	if (addedXP >= levelUpXP) {
+	if (addedExperience >= levelUpXP) {
 		const newRole = levelRole[newLevel];
 		if (newRole) {
 			for (const role of Object.values(levelRole)) {

--- a/src/modules/level/events/message.ts
+++ b/src/modules/level/events/message.ts
@@ -1,7 +1,7 @@
 import {Events} from "discord.js";
 import {client} from "../../../bot";
 import {sleep} from "../../../lib/utils";
-import {addXP} from "../addXp";
+import {addUserExperience} from "../addUserExperience";
 import {evalTextMessage} from "../levelHelper";
 import {Deque} from "../deque";
 
@@ -70,7 +70,7 @@ export async function initMessageXPEvaluator() {
 		// Add XP based on evaluation
 		// daytime is the current time of day in minutes
 		const daytime = new Date().getHours() * 60 + new Date().getMinutes();
-		await addXP(message.member, evalTextMessage(message, daytime, server_activity_hour, user_activity_day, user_activity_week));
+		await addUserExperience(message.member, evalTextMessage(message, daytime, server_activity_hour, user_activity_day, user_activity_week));
 
 		// Wait for cooldown
 		await sleep(10000);

--- a/src/modules/level/events/voice.ts
+++ b/src/modules/level/events/voice.ts
@@ -1,6 +1,6 @@
 import {Events} from "discord.js";
 import {client} from "../../../bot";
-import {addXP} from "../addXp";
+import {addUserExperience} from "../addUserExperience";
 import {levellingConfig, timeofdayPenalty} from "../levelHelper";
 
 const currentUserInVoice: { [key: string]: VoiceMode } = {};
@@ -39,11 +39,11 @@ export async function initXPVoiceEvaluator() {
 					const timeofday: number = new Date().getHours() * 60 + new Date().getMinutes();
 					// Add XP based on mute state
 					if (currentUserInVoice[user.id] == VoiceMode.FULL) {
-						addXP(user, levellingConfig.VOICE_UNMUTE_MULTIPLIER * levellingConfig.VOICE_PER_MINUTE_BASE_EXP * (timeofdayPenalty(timeofday) ? 0 : 1));
+						addUserExperience(user, levellingConfig.VOICE_UNMUTE_MULTIPLIER * levellingConfig.VOICE_PER_MINUTE_BASE_EXP * (timeofdayPenalty(timeofday) ? 0 : 1));
 					} else if (currentUserInVoice[user.id] == VoiceMode.HALF) {
-						addXP(user, levellingConfig.VOICE_MUTE_MULTIPLIER * levellingConfig.VOICE_PER_MINUTE_BASE_EXP * (timeofdayPenalty(timeofday) ? 0 : 1));
+						addUserExperience(user, levellingConfig.VOICE_MUTE_MULTIPLIER * levellingConfig.VOICE_PER_MINUTE_BASE_EXP * (timeofdayPenalty(timeofday) ? 0 : 1));
 					} else {
-						addXP(user, levellingConfig.VOICE_DEAF_MULTIPLIER * levellingConfig.VOICE_PER_MINUTE_BASE_EXP * (timeofdayPenalty(timeofday) ? 0 : 1));
+						addUserExperience(user, levellingConfig.VOICE_DEAF_MULTIPLIER * levellingConfig.VOICE_PER_MINUTE_BASE_EXP * (timeofdayPenalty(timeofday) ? 0 : 1));
 					}
 				}, 60 * 1000);
 			}

--- a/src/modules/level/levelHelper.ts
+++ b/src/modules/level/levelHelper.ts
@@ -35,34 +35,34 @@ export const levellingConfig = {
 
 /**
  * Calculate the level of a user based on their XP
- * @param xp the XP of the user
+ * @param user_experience the XP of the user
  */
-export function calcLevel(xp: number): number {
-	return xp < 0 ? 0 :
+export function calcLevel(user_experience: number): number {
+	return user_experience < 0 ? 0 :
 		Math.min(
 			Math.floor(
 				Math.sqrt(
-					xp / levellingConfig.LEVELLING_FUNCTION_FACTOR)),
+					user_experience / levellingConfig.LEVELLING_FUNCTION_FACTOR)),
 			levellingConfig.MAX_LEVEL);
 }
 
 /**
  * Calculate the XP required to reach the next level
- * @param xp the XP of the user
+ * @param user_experience the XP of the user
  */
-export function xpToNextLevel(xp: number): number {
-	return xp < 0 ? levellingConfig.LEVELLING_FUNCTION_FACTOR :
-		levellingConfig.LEVELLING_FUNCTION_FACTOR * Math.pow(calcLevel(xp) + 1, 2) - xp;
+export function xpToNextLevel(user_experience: number): number {
+	return user_experience < 0 ? levellingConfig.LEVELLING_FUNCTION_FACTOR :
+		levellingConfig.LEVELLING_FUNCTION_FACTOR * Math.pow(calcLevel(user_experience) + 1, 2) - user_experience;
 }
 
-export function xpFromThisLevel(xp: number): number {
-	return xp < 0 ? 0 :
-		levellingConfig.LEVELLING_FUNCTION_FACTOR * Math.pow(calcLevel(xp), 2);
+export function xpFromThisLevel(user_experience: number): number {
+	return user_experience < 0 ? 0 :
+		user_experience - levellingConfig.LEVELLING_FUNCTION_FACTOR * Math.pow(calcLevel(user_experience), 2);
 }
 
 
 /**
- * Evaluate the XP of a message, considering the current activity, both server and user
+ * Evaluate the user experience gained from a message, considering the current activity, both server and user
  * @param text the message to evaluate
  * @param daytime the time of day, from 0 to 1440 minutes (24h * 60m)
  * @param server_activity number of messages on the server in the last HOUR


### PR DESCRIPTION
This proposal was made to reduce mistakes and prevent misunderstanding. All methods are supposed to use the same units of experience.